### PR TITLE
Extract AppPackage into its own, er, package

### DIFF
--- a/packages/app-package/LICENSE
+++ b/packages/app-package/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2018 Fitbit, Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/app-package/README.md
+++ b/packages/app-package/README.md
@@ -1,0 +1,4 @@
+@fitbit/app-package
+===================
+
+Utilities for reading FBA files.

--- a/packages/app-package/jest.config.js
+++ b/packages/app-package/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  ...require('../jest.config.base'),
+  // displayName must be set to work around buggy jest behaviour.
+  // https://github.com/facebook/jest/issues/5597
+  displayName: require('./package.json').name,
+};

--- a/packages/app-package/package.json
+++ b/packages/app-package/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@fitbit/app-package",
+  "version": "1.0.0",
+  "author": "Fitbit, Inc.",
+  "license": "BSD-3-Clause",
+  "description": "Utilities for reading FBA files",
+  "repository": "github:Fitbit/developer-bridge",
+  "bugs": {
+    "url": "https://github.com/Fitbit/developer-bridge/issues"
+  },
+  "homepage": "https://github.com/Fitbit/developer-bridge/tree/master/packages/app-package#readme",
+  "main": "lib/AppPackage.js",
+  "types": "lib/AppPackage.d.ts",
+  "scripts": {
+    "build": "rm -rf lib && tsc -b",
+    "prepublishOnly": "yarn run build"
+  },
+  "files": [
+    "/lib/!(*.test|*.spec).{js,d.ts}"
+  ],
+  "dependencies": {
+    "apr-map": "^3.0.3",
+    "lodash": "^4.17.11",
+    "tslib": "^1.9.3"
+  },
+  "devDependencies": {
+    "@types/jszip": "^3.1.4",
+    "@types/lodash": "^4.14.116",
+    "@types/node": "^10.11.4",
+    "jszip": "^3.1.5"
+  }
+}

--- a/packages/app-package/src/__snapshots__/AppPackage.test.ts.snap
+++ b/packages/app-package/src/__snapshots__/AppPackage.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fromArtifact accepts a v5 manifest with a companion 1`] = `
-AppPackage {
+exports[`fromJSZip accepts a v5 manifest with a companion 1`] = `
+Object {
   "buildId": "0x0123456789abcdef",
   "components": Object {
     "companion": Object {
@@ -35,18 +35,6 @@ AppPackage {
       },
     },
   },
-  "manifest": Object {
-    "appId": "eff9d309-eadd-41d7-9af3-696eafc3fa31",
-    "buildId": "0x0123456789abcdef",
-    "components": Object {
-      "companion": "companion.zip",
-      "watch": "device.zip",
-    },
-    "manifestVersion": 5,
-    "platform": Array [
-      "HIGGS",
-    ],
-  },
   "requestedPermissions": undefined,
   "sdkVersion": Object {
     "companionApi": "1.0.0",
@@ -57,8 +45,8 @@ AppPackage {
 }
 `;
 
-exports[`fromArtifact accepts a v5 manifest with a versioned platform 1`] = `
-AppPackage {
+exports[`fromJSZip accepts a v5 manifest with a versioned platform 1`] = `
+Object {
   "buildId": "0x0123456789abcdef",
   "components": Object {
     "companion": undefined,
@@ -94,17 +82,6 @@ AppPackage {
       },
     },
   },
-  "manifest": Object {
-    "appId": "eff9d309-eadd-41d7-9af3-696eafc3fa31",
-    "buildId": "0x0123456789abcdef",
-    "components": Object {
-      "watch": "device.zip",
-    },
-    "manifestVersion": 5,
-    "platform": Array [
-      "HIGGS:32.1.16+",
-    ],
-  },
   "requestedPermissions": undefined,
   "sdkVersion": Object {
     "deviceApi": "1.0.0",
@@ -114,8 +91,8 @@ AppPackage {
 }
 `;
 
-exports[`fromArtifact accepts a v5 manifest with an unversioned platform 1`] = `
-AppPackage {
+exports[`fromJSZip accepts a v5 manifest with an unversioned platform 1`] = `
+Object {
   "buildId": "0x0123456789abcdef",
   "components": Object {
     "companion": undefined,
@@ -149,17 +126,6 @@ AppPackage {
       },
     },
   },
-  "manifest": Object {
-    "appId": "eff9d309-eadd-41d7-9af3-696eafc3fa31",
-    "buildId": "0x0123456789abcdef",
-    "components": Object {
-      "watch": "device.zip",
-    },
-    "manifestVersion": 5,
-    "platform": Array [
-      "HIGGS",
-    ],
-  },
   "requestedPermissions": undefined,
   "sdkVersion": Object {
     "deviceApi": "1.0.0",
@@ -169,8 +135,8 @@ AppPackage {
 }
 `;
 
-exports[`fromArtifact accepts a v5 manifest with multiple platforms 1`] = `
-AppPackage {
+exports[`fromJSZip accepts a v5 manifest with multiple platforms 1`] = `
+Object {
   "buildId": "0x0123456789abcdef",
   "components": Object {
     "companion": undefined,
@@ -235,18 +201,6 @@ AppPackage {
       },
     },
   },
-  "manifest": Object {
-    "appId": "eff9d309-eadd-41d7-9af3-696eafc3fa31",
-    "buildId": "0x0123456789abcdef",
-    "components": Object {
-      "watch": "device.zip",
-    },
-    "manifestVersion": 5,
-    "platform": Array [
-      "HIGGS:32.1.16+",
-      "MESON:1.2.3+",
-    ],
-  },
   "requestedPermissions": undefined,
   "sdkVersion": Object {
     "deviceApi": "1.0.0",
@@ -256,8 +210,8 @@ AppPackage {
 }
 `;
 
-exports[`fromArtifact accepts a v6 manifest with a companion 1`] = `
-AppPackage {
+exports[`fromJSZip accepts a v6 manifest with a companion 1`] = `
+Object {
   "buildId": "0x0123456789abcdef",
   "components": Object {
     "companion": Object {
@@ -290,21 +244,6 @@ AppPackage {
       },
     },
   },
-  "manifest": Object {
-    "appId": "eff9d309-eadd-41d7-9af3-696eafc3fa31",
-    "buildId": "0x0123456789abcdef",
-    "components": Object {
-      "companion": Object {
-        "filename": "companion.zip",
-      },
-      "watch": Object {
-        "higgs": Object {
-          "filename": "higgs.zip",
-        },
-      },
-    },
-    "manifestVersion": 6,
-  },
   "requestedPermissions": undefined,
   "sdkVersion": Object {
     "companionApi": "1.0.0",
@@ -315,8 +254,8 @@ AppPackage {
 }
 `;
 
-exports[`fromArtifact accepts a v6 manifest with multiple device components 1`] = `
-AppPackage {
+exports[`fromJSZip accepts a v6 manifest with multiple device components 1`] = `
+Object {
   "buildId": "0x0123456789abcdef",
   "components": Object {
     "companion": undefined,
@@ -354,28 +293,6 @@ AppPackage {
       },
     },
   },
-  "manifest": Object {
-    "appId": "eff9d309-eadd-41d7-9af3-696eafc3fa31",
-    "buildId": "0x0123456789abcdef",
-    "components": Object {
-      "watch": Object {
-        "higgs": Object {
-          "filename": "higgs.zip",
-          "platform": Array [
-            "23.1.5",
-            "32.4.16+",
-          ],
-        },
-        "meson": Object {
-          "filename": "meson.zip",
-          "platform": Array [
-            "32.4.17+",
-          ],
-        },
-      },
-    },
-    "manifestVersion": 6,
-  },
   "requestedPermissions": undefined,
   "sdkVersion": Object {
     "deviceApi": "1.0.0",
@@ -385,8 +302,8 @@ AppPackage {
 }
 `;
 
-exports[`fromArtifact accepts a v6 manifest with no device component 1`] = `
-AppPackage {
+exports[`fromJSZip accepts a v6 manifest with no device component 1`] = `
+Object {
   "buildId": "0x0123456789abcdef",
   "components": Object {
     "companion": Object {
@@ -394,16 +311,6 @@ AppPackage {
       "type": "Buffer",
     },
     "device": Object {},
-  },
-  "manifest": Object {
-    "appId": "eff9d309-eadd-41d7-9af3-696eafc3fa31",
-    "buildId": "0x0123456789abcdef",
-    "components": Object {
-      "companion": Object {
-        "filename": "companion.zip",
-      },
-    },
-    "manifestVersion": 6,
   },
   "requestedPermissions": undefined,
   "sdkVersion": Object {
@@ -415,8 +322,8 @@ AppPackage {
 }
 `;
 
-exports[`fromArtifact accepts a v6 manifest with no platform spec for the device 1`] = `
-AppPackage {
+exports[`fromJSZip accepts a v6 manifest with no platform spec for the device 1`] = `
+Object {
   "buildId": "0x0123456789abcdef",
   "components": Object {
     "companion": undefined,
@@ -449,18 +356,6 @@ AppPackage {
       },
     },
   },
-  "manifest": Object {
-    "appId": "eff9d309-eadd-41d7-9af3-696eafc3fa31",
-    "buildId": "0x0123456789abcdef",
-    "components": Object {
-      "watch": Object {
-        "higgs": Object {
-          "filename": "higgs.zip",
-        },
-      },
-    },
-    "manifestVersion": 6,
-  },
   "requestedPermissions": undefined,
   "sdkVersion": Object {
     "deviceApi": "1.0.0",
@@ -470,26 +365,24 @@ AppPackage {
 }
 `;
 
-exports[`fromArtifact rejects a manifest that is not JSON 1`] = `[SyntaxError: Unexpected token N in JSON at position 0]`;
+exports[`fromJSZip rejects a manifest that is not JSON 1`] = `[SyntaxError: Unexpected token N in JSON at position 0]`;
 
-exports[`fromArtifact rejects a manifest with unsupported version 1`] = `[Error: Unsupported manifest version 100]`;
+exports[`fromJSZip rejects a manifest with unsupported version 1`] = `[Error: Unsupported manifest version 100]`;
 
-exports[`fromArtifact rejects a non-zip file 1`] = `[Error: End of data reached (data length = 0, asked index = 4). Corrupted zip ?]`;
+exports[`fromJSZip rejects a v5 manifest which references a nonexistent companion component file 1`] = `[Error: companion.zip not present in zip file]`;
 
-exports[`fromArtifact rejects a v5 manifest which references a nonexistent companion component file 1`] = `[Error: companion.zip not present in zip file]`;
+exports[`fromJSZip rejects a v5 manifest which references a nonexistent device component file 1`] = `[Error: doesnotexist.zip not present in zip file]`;
 
-exports[`fromArtifact rejects a v5 manifest which references a nonexistent device component file 1`] = `[Error: doesnotexist.zip not present in zip file]`;
+exports[`fromJSZip rejects a v5 manifest with mistyped components 1`] = `[Error: No components listed in manifest.json]`;
 
-exports[`fromArtifact rejects a v5 manifest with mistyped components 1`] = `[Error: No components listed in manifest.json]`;
+exports[`fromJSZip rejects a v5 manifest with no device component 1`] = `[Error: No components listed in manifest.json]`;
 
-exports[`fromArtifact rejects a v5 manifest with no device component 1`] = `[Error: No components listed in manifest.json]`;
+exports[`fromJSZip rejects a v5 manifest with no platform descriptor 1`] = `[Error: Missing platform descriptors]`;
 
-exports[`fromArtifact rejects a v5 manifest with no platform descriptor 1`] = `[Error: Missing platform descriptors]`;
+exports[`fromJSZip rejects a v6 manifest which references a nonexistent companion component file 1`] = `[Error: companion.zip not present in zip file]`;
 
-exports[`fromArtifact rejects a v6 manifest which references a nonexistent companion component file 1`] = `[Error: companion.zip not present in zip file]`;
+exports[`fromJSZip rejects a v6 manifest which references a nonexistent device component file 1`] = `[Error: doesnotexist.zip not present in zip file]`;
 
-exports[`fromArtifact rejects a v6 manifest which references a nonexistent device component file 1`] = `[Error: doesnotexist.zip not present in zip file]`;
+exports[`fromJSZip rejects a v6 manifest with mistyped components 1`] = `[Error: No components listed in manifest.json]`;
 
-exports[`fromArtifact rejects a v6 manifest with mistyped components 1`] = `[Error: No components listed in manifest.json]`;
-
-exports[`fromArtifact rejects a zip file without a manifest 1`] = `[Error: manifest.json not present in zip file]`;
+exports[`fromJSZip rejects a zip file without a manifest 1`] = `[Error: manifest.json not present in zip file]`;

--- a/packages/app-package/tsconfig.json
+++ b/packages/app-package/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.settings.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+  },
+}

--- a/packages/sdk-cli/package.json
+++ b/packages/sdk-cli/package.json
@@ -14,6 +14,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
+    "@fitbit/app-package": "^1.0.0",
     "@fitbit/fdb-debugger": "^1.3.1",
     "@fitbit/fdb-host": "^1.3.1",
     "@fitbit/fdb-protocol": "^1.3.1",

--- a/packages/sdk-cli/src/models/AppContext.test.ts
+++ b/packages/sdk-cli/src/models/AppContext.test.ts
@@ -1,10 +1,13 @@
+import { fromJSZip } from '@fitbit/app-package';
 import AppContext from '../models/AppContext';
-import AppPackage from '../models/AppPackage';
 import * as promiseFs from '../util/promiseFs';
+
+jest.mock('@fitbit/app-package');
+
+const emptyZip = Buffer.from('UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA==', 'base64');
 
 let appContext: AppContext;
 let readFileSpy: jest.MockInstance<typeof promiseFs.readFile>;
-let appPackageSpy: jest.MockInstance<typeof AppPackage.fromArtifact>;
 let appPackageLoadedSpy: jest.Mock;
 
 const mockPreviousApp = {
@@ -29,7 +32,7 @@ describe.each([
     appContext.onAppPackageLoad.attach(appPackageLoadedSpy);
 
     readFileSpy = jest.spyOn(promiseFs, 'readFile');
-    appPackageSpy = jest.spyOn(AppPackage, 'fromArtifact');
+    (fromJSZip as any).mockReset();
   });
 
   describe('if the file path cannot be read', () => {
@@ -49,8 +52,8 @@ describe.each([
     const error = new Error('Failed to parse package');
 
     beforeEach(() => {
-      readFileSpy.mockResolvedValueOnce(Buffer.alloc(0));
-      appPackageSpy.mockRejectedValueOnce(error);
+      readFileSpy.mockResolvedValueOnce(emptyZip);
+      (fromJSZip as any).mockRejectedValueOnce(error);
     });
 
     it('rejects', () => expect(loadAppPackage()).rejects.toBe(error));
@@ -68,8 +71,8 @@ describe.each([
     };
 
     beforeEach(() => {
-      readFileSpy.mockResolvedValueOnce(Buffer.alloc(0));
-      appPackageSpy.mockResolvedValueOnce(mockApp);
+      readFileSpy.mockResolvedValueOnce(emptyZip);
+      (fromJSZip as any).mockResolvedValueOnce(mockApp);
       return loadAppPackage();
     });
 

--- a/packages/sdk-cli/src/models/AppContext.ts
+++ b/packages/sdk-cli/src/models/AppContext.ts
@@ -1,6 +1,7 @@
+import { AppPackage, fromJSZip } from '@fitbit/app-package';
+import JSZip from 'jszip';
 import { VoidSyncEvent } from 'ts-events';
 
-import AppPackage from './AppPackage';
 import { readFile } from '../util/promiseFs';
 
 export interface AppPackageStore {
@@ -14,8 +15,7 @@ class AppContext implements AppPackageStore {
   public appPackagePath?: string;
 
   async loadAppPackage(packagePath: string) {
-    const appPackageData = await readFile(packagePath);
-    this.appPackage = await AppPackage.fromArtifact(appPackageData);
+    this.appPackage = await readFile(packagePath).then(JSZip.loadAsync).then(fromJSZip);
     this.appPackagePath = packagePath;
 
     this.onAppPackageLoad.post();

--- a/packages/sdk-cli/src/models/LogConsumer.ts
+++ b/packages/sdk-cli/src/models/LogConsumer.ts
@@ -1,9 +1,9 @@
+import { ComponentSourceMaps } from '@fitbit/app-package';
 import { ConsoleMessage, ConsoleTrace, RemoteHost } from '@fitbit/fdb-debugger';
 import lodash from 'lodash';
 import { SourceMapConsumer } from 'source-map';
 
 import { AppPackageStore } from './AppContext';
-import { ComponentSourceMaps } from './AppPackage';
 import * as compatibility from '../models/compatibility';
 import HostConnections, { HostAddedEvent } from './HostConnections';
 import mapValues from '../util/mapValues';
@@ -77,7 +77,7 @@ export default class LogConsumer {
     }
 
     const sourceMapConsumers = await mapValues(lodash(sourceMaps).pickBy().value(), async maps =>
-      mapValues(maps!, async map => new SourceMapConsumer(map)));
+      mapValues(maps!, async map => new SourceMapConsumer(map as any)));
 
     this.componentSourceMapConsumers = {
       ...this.componentSourceMapConsumers,

--- a/packages/sdk-cli/src/models/compatibility.test.ts
+++ b/packages/sdk-cli/src/models/compatibility.test.ts
@@ -1,10 +1,10 @@
+import { AppPackage } from '@fitbit/app-package';
 import { FDBTypes } from '@fitbit/fdb-protocol';
 
-import AppPackage from './AppPackage';
 import { findCompatibleAppComponent, assertCompanionComponentIsCompatible } from './compatibility';
 
 function makeAppPackage(...families: string[]) {
-  const appPackage = new AppPackage({
+  const appPackage: AppPackage = {
     uuid: '',
     buildId: '',
     requestedPermissions: [],
@@ -14,7 +14,7 @@ function makeAppPackage(...families: string[]) {
     sdkVersion: {
       deviceApi: '1.0.0',
     },
-  });
+  };
   families.forEach((name) => {
     appPackage.components.device[name] = {
       artifact: Buffer.alloc(0),

--- a/packages/sdk-cli/src/models/compatibility.ts
+++ b/packages/sdk-cli/src/models/compatibility.ts
@@ -1,10 +1,9 @@
+import { AppPackage } from '@fitbit/app-package';
 import { FDBTypes } from '@fitbit/fdb-protocol';
 import { default as ErrorSubclass } from 'error-subclass';
 import humanizeList from 'humanize-list';
 import lodash from 'lodash';
 import semver from 'semver';
-
-import AppPackage from './AppPackage';
 
 class CompatibilityError extends ErrorSubclass {
   static displayName = 'CompatibilityError';

--- a/packages/sdk-cli/src/models/sideload.ts
+++ b/packages/sdk-cli/src/models/sideload.ts
@@ -1,6 +1,6 @@
+import { AppPackage } from '@fitbit/app-package';
 import { RemoteHost } from '@fitbit/fdb-debugger';
 
-import AppPackage from '../models/AppPackage';
 import * as compatibility from '../models/compatibility';
 
 type ProgressCallback = (sent: number, total: number) => void;

--- a/packages/sdk-cli/tsconfig.json
+++ b/packages/sdk-cli/tsconfig.json
@@ -20,6 +20,7 @@
     "src/auth/environments.json",
   ],
   "references": [
+    { "path": "../app-package" },
     { "path": "../fdb-debugger" },
     { "path": "../fdb-host" },
     { "path": "../fdb-protocol" },

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "files": [],
   "references": [
+    { "path": "app-package" },
     { "path": "fdb-protocol" },
     { "path": "fdb-host" },
     { "path": "fdb-debugger" },

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "strict-boolean-expressions": false,
     "prefer-template": [true, "allow-single-concat"],
     "import-name": [true, {
+      "appPackage": "AppPackage",
       "jszip": "JSZip",
       "mockFs": "mockFS",
       "portablePixmap": "PortablePixmap",

--- a/types/apr-map/index.d.ts
+++ b/types/apr-map/index.d.ts
@@ -1,0 +1,16 @@
+declare function map<T, TResult>(
+  input: T[],
+  iteratee: (value: T, index: number, collection: T[]) => Promise<TResult>,
+): Promise<TResult[]>;
+
+declare function map<T, TResult, Input extends Iterable<T>>(
+  input: Input,
+  iteratee: (value: T, index: number, collection: Input) => Promise<TResult>,
+): Promise<TResult[]>;
+
+declare function map<T extends object, TResult>(
+  input: T,
+  iteratee: (value: T[keyof T], index: string, collection: T) => Promise<TResult>,
+): Promise<{ [K in keyof T]: TResult }>;
+
+export default map;

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,7 +639,7 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/keytar/-/keytar-4.0.1.tgz#e2cf6405dc33861424e59b67516c66d2cf7bc21b"
 
-"@types/lodash@^4.14.104", "@types/lodash@^4.14.110":
+"@types/lodash@^4.14.104", "@types/lodash@^4.14.110", "@types/lodash@^4.14.116":
   version "4.14.116"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
 
@@ -664,6 +664,10 @@
     "@types/node" "*"
 
 "@types/node@*":
+  version "10.11.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
+
+"@types/node@^10.11.4":
   version "10.11.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
 
@@ -916,6 +920,47 @@ append-transform@^0.4.0:
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
   dependencies:
     default-require-extensions "^1.0.0"
+
+apr-engine-each@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/apr-engine-each/-/apr-engine-each-3.0.3.tgz#1d678537c89380b6987c5c1f0aac7a7dca3e63c8"
+  dependencies:
+    apr-engine-run "^3.0.3"
+    lodash.defaults "^4.2.0"
+
+apr-engine-iterator@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/apr-engine-iterator/-/apr-engine-iterator-3.0.3.tgz#013415eae0acebb569daa6cfb7e25698101d4f5d"
+  dependencies:
+    apr-engine-until "^3.0.3"
+    build-array "^1.0.0"
+    lodash.isarraylike "^4.2.0"
+    lodash.isfinite "^3.3.2"
+    lodash.keys "^4.2.0"
+
+apr-engine-run@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/apr-engine-run/-/apr-engine-run-3.0.3.tgz#c7f3e6e31f12de636d00e84be22160fe82569990"
+  dependencies:
+    apr-engine-iterator "^3.0.3"
+
+apr-engine-sum@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/apr-engine-sum/-/apr-engine-sum-3.0.3.tgz#48af1a89d3a7fb60745d32118a51bd225a26732b"
+  dependencies:
+    lodash.isarraylike "^4.2.0"
+
+apr-engine-until@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/apr-engine-until/-/apr-engine-until-3.0.3.tgz#0168a429e1f6ad054cc8fbe2edff65663f92e9cb"
+
+apr-map@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/apr-map/-/apr-map-3.0.3.tgz#2bf91e9aeb18794bc95631311d6e94741ef16dc2"
+  dependencies:
+    apr-engine-each "^3.0.3"
+    apr-engine-sum "^3.0.3"
+    lodash.defaults "^4.2.0"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -1349,6 +1394,12 @@ buffer-fill@^1.0.0:
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+
+build-array@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/build-array/-/build-array-1.0.0.tgz#385e66f6b05c29ff16870c6e9944ccae77f7f100"
+  dependencies:
+    type-component "0.0.1"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -3891,6 +3942,22 @@ lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
+lodash.isarraylike@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarraylike/-/lodash.isarraylike-4.2.0.tgz#4623310ab318804b667ddc3619058137559400c4"
+
+lodash.isfinite@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
+
+lodash.keys@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -3912,7 +3979,7 @@ lodash@^3.3.1:
   version "3.10.1"
   resolved "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.5.1:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.5.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -6044,6 +6111,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-component@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/type-component/-/type-component-0.0.1.tgz#952a6c81c21efd24d13d811d0c8498cb860e1956"
 
 type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"


### PR DESCRIPTION
Make the AppPackage parsing and loading logic available to other
packages outside of the CLI debugger. And tweak the API a bit.

Strip out the package generation logic as it is no longer used anywhere.

Change the loader function to take a JSZip instance as an argument. This
decouples it from the actual loading of the zip file and eliminates the
direct dependency on JSZip.

Change the parsed `AppPackage` instances to be plain old data objects.
Remove the constructor.

Export the loader function individually. Future loaders and utility
functions will also be exported individually so that this package can be
tree-shaken.

Drop the deprecated `manifest` property from the parsed AppPackage
object. Any consumer that relied on that property can replicate the
functionality by reading and parsing `manifest.json` directly from the
app package ZIP file.
```js
const manifest = await packageZip.file('manifest.json')
  .async('text')
  .then(JSON.parse);
```