### PR TITLE
Use cbor-js instead of cbor for browser build compatibility

### DIFF
--- a/packages/fdb-debugger/package.json
+++ b/packages/fdb-debugger/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@fitbit/fdb-protocol": "^1.5.0-pre.3",
     "@fitbit/jsonrpc-ts": "^1.0.1",
-    "cbor": "^4.1.1",
+    "cbor-js": "^0.1.0",
     "io-ts": "^1.2.1",
     "jszip": "^3.1.5",
     "lodash": "^4.17.4",
@@ -29,7 +29,6 @@
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@types/cbor": "^2.0.0",
     "@types/duplexify": "^3.5.0",
     "@types/jszip": "^3.1.4",
     "@types/lodash": "^4.14.104",

--- a/packages/fdb-debugger/src/ConfigurableEncode.ts
+++ b/packages/fdb-debugger/src/ConfigurableEncode.ts
@@ -1,12 +1,12 @@
 import { Transform } from 'stream';
 
 import { FDBTypes } from '@fitbit/fdb-protocol';
-import * as cbor from 'cbor';
+import * as cbor from 'cbor-js';
 
 export type EncoderCallback = (data: any) => Buffer | string;
 
 const encoders: {[key in FDBTypes.SerializationType]: (data: any) => Buffer | string} = {
-  'cbor-definite': cbor.encode,
+  'cbor-definite': buf => Buffer.from(cbor.encode(buf)),
   json: JSON.stringify,
 };
 

--- a/types/cbor-js/index.d.ts
+++ b/types/cbor-js/index.d.ts
@@ -1,0 +1,6 @@
+declare namespace CBOR {
+  function encode(obj: any): ArrayBuffer;
+  function decode(buf: ArrayBuffer): object;
+}
+
+export = CBOR;

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,13 +582,6 @@
     opener "^1.4.3"
     request "^2.87.0"
 
-"@types/cbor@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/cbor/-/cbor-2.0.0.tgz#c627afc2ee22f23f2337fecb34628a4f97c6afbb"
-  integrity sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=
-  dependencies:
-    "@types/node" "*"
-
 "@types/dateformat@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-1.0.1.tgz#2e5b235c8c55652c4fec284506d2a36fe65fe87e"
@@ -1333,11 +1326,6 @@ big-time@2.x.x:
   resolved "https://registry.yarnpkg.com/big-time/-/big-time-2.0.1.tgz#68c7df8dc30f97e953f25a67a76ac9713c16c9de"
   integrity sha1-aMffjcMPl+lT8lpnp2rJcTwWyd4=
 
-bignumber.js@^7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
-  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
-
 bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
@@ -1586,15 +1574,10 @@ catbox@10.x.x:
     hoek "5.x.x"
     joi "13.x.x"
 
-cbor@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/cbor/-/cbor-4.1.1.tgz#a6bc17020b45685d315c6bbc971f3bb3c973fde9"
-  integrity sha512-x9Pc1gT3JxUEZTOA9YdRdpg8hohBEFPAc26c85PlGYvzoc77PXr1lvfBKmBPFcf7eYsOs0hWRWWmfqJozrvDnw==
-  dependencies:
-    bignumber.js "^7.2.1"
-    commander "^2.16.0"
-    json-text-sequence "^0.1"
-    nofilter "^0.0.3"
+cbor-js@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/cbor-js/-/cbor-js-0.1.0.tgz#c80ce6120f387e8faa74370dfda21d965b8fc7f9"
+  integrity sha1-yAzmEg84fo+qdDcN/aIdlluPx/k=
 
 chai@^4.1.2:
   version "4.2.0"
@@ -1745,11 +1728,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
 commander@^2.12.1:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
-
-commander@^2.16.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -2133,11 +2111,6 @@ delayed-stream@~1.0.0:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-
-delimit-stream@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/delimit-stream/-/delimit-stream-0.1.0.tgz#9b8319477c0e5f8aeb3ce357ae305fc25ea1cd2b"
-  integrity sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -3904,13 +3877,6 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json-text-sequence@^0.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/json-text-sequence/-/json-text-sequence-0.1.1.tgz#a72f217dc4afc4629fff5feb304dc1bd51a2f3d2"
-  integrity sha1-py8hfcSvxGKf/1/rME3BvVGi89I=
-  dependencies:
-    delimit-stream "0.1.0"
-
 json5@2.x:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
@@ -4606,11 +4572,6 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
-
-nofilter@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-0.0.3.tgz#241e342078177a8693a3043e83f37567e276410c"
-  integrity sha1-JB40IHgXeoaTowQ+g/N1Z+J2QQw=
 
 noop-logger@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
node-cbor isn't ES5 and so breaks in the Studio build. cbor-js and looks like it'll work, so let's use that instead since node-cbor hasn't landed our PR. I can't test it in the Studio build because the simple-sha256 dependency also breaks out build.