### PR TITLE
Reject the build action when the build child process fails

### DIFF
--- a/packages/sdk-cli/src/commands/build.test.ts
+++ b/packages/sdk-cli/src/commands/build.test.ts
@@ -15,15 +15,15 @@ beforeEach(() => {
   childProcessSpawnSpy.mockImplementationOnce(() => childProcessMock);
 });
 
-it('resolves if the build process exits with code 0', () => {
+it('resolves with the code and signal when the build process exits', () => {
   const buildPromise = buildProcess();
   expect(childProcessSpawnSpy).toBeCalled();
   childProcessMock.emit('exit', 0);
-  return expect(buildPromise).resolves.toBeUndefined();
+  return expect(buildPromise).resolves.toEqual({ code: 0 });
 });
 
-it('rejects if the build process exits with a non-zero code', () => {
+it('rejects if the build process emits an error', () => {
   const buildPromise = buildProcess();
-  childProcessMock.emit('exit', 5);
-  return expect(buildPromise).rejects.toBe(5);
+  childProcessMock.emit('error', 'some error');
+  return expect(buildPromise).rejects.toBe('some error');
 });

--- a/packages/sdk-cli/src/commands/build.test.ts
+++ b/packages/sdk-cli/src/commands/build.test.ts
@@ -1,0 +1,29 @@
+import child_process from 'child_process';
+import { EventEmitter } from 'events';
+
+import { buildProcess } from './build';
+
+jest.mock('child_process');
+
+let childProcessSpawnSpy: jest.MockInstance<typeof child_process.spawn>;
+let childProcessMock: EventEmitter;
+
+beforeEach(() => {
+  childProcessMock = new EventEmitter();
+
+  childProcessSpawnSpy = jest.spyOn(child_process, 'spawn');
+  childProcessSpawnSpy.mockImplementationOnce(() => childProcessMock);
+});
+
+it('resolves if the build process exits with code 0', () => {
+  const buildPromise = buildProcess();
+  expect(childProcessSpawnSpy).toBeCalled();
+  childProcessMock.emit('exit', 0);
+  return expect(buildPromise).resolves.toBeUndefined();
+});
+
+it('rejects if the build process exits with a non-zero code', () => {
+  const buildPromise = buildProcess();
+  childProcessMock.emit('exit', 5);
+  return expect(buildPromise).rejects.toBe(5);
+});

--- a/packages/sdk-cli/src/commands/build.ts
+++ b/packages/sdk-cli/src/commands/build.ts
@@ -5,16 +5,15 @@ import fsExtra from 'fs-extra';
 import lodash from 'lodash';
 import vorpal from 'vorpal';
 
-export const buildProcess = () => {
+export const buildProcess = (): Promise<{code?: number, signal?: string}> => {
   return new Promise((resolve, reject) => {
     const buildProcess = child_process.spawn(
       'npm',
       ['run-script', 'build'],
       { stdio: 'inherit', shell: true },
     );
-    buildProcess.on('exit', (code) => {
-      code === 0 ? resolve() : reject(code);
-    });
+    buildProcess.on('exit', (code, signal) => resolve({ code, signal }));
+    buildProcess.on('error', reject);
   });
 };
 
@@ -45,7 +44,25 @@ export const buildAction = async (cli: vorpal) => {
       { spaces: 2, EOL: os.EOL },
     );
   }
-  return buildProcess();
+
+  return buildProcess()
+    .then(({ code, signal }) => {
+      if (signal) {
+        cli.activeCommand.log(`Build failed with signal: ${signal}`);
+        return false;
+      }
+
+      if (code && code !== 0) {
+        cli.activeCommand.log(`Build failed with code: ${code}`);
+        return false;
+      }
+
+      return true;
+    })
+    .catch((error) => {
+      cli.activeCommand.log(`Build failed with error: ${error}`);
+      return false;
+    });
 };
 
 export default function build(cli: vorpal) {

--- a/packages/sdk-cli/src/commands/build.ts
+++ b/packages/sdk-cli/src/commands/build.ts
@@ -5,6 +5,19 @@ import fsExtra from 'fs-extra';
 import lodash from 'lodash';
 import vorpal from 'vorpal';
 
+export const buildProcess = () => {
+  return new Promise((resolve, reject) => {
+    const buildProcess = child_process.spawn(
+      'npm',
+      ['run-script', 'build'],
+      { stdio: 'inherit', shell: true },
+    );
+    buildProcess.on('exit', (code) => {
+      code === 0 ? resolve() : reject(code);
+    });
+  });
+};
+
 export const buildAction = async (cli: vorpal) => {
   const packageJSONPath = 'package.json';
   const packageJSON = await fsExtra.readJSON(packageJSONPath);
@@ -32,15 +45,7 @@ export const buildAction = async (cli: vorpal) => {
       { spaces: 2, EOL: os.EOL },
     );
   }
-
-  return new Promise((resolve) => {
-    const buildProcess = child_process.spawn(
-      'npm',
-      ['run-script', 'build'],
-      { stdio: 'inherit', shell: true },
-    );
-    buildProcess.on('exit', resolve);
-  });
+  return buildProcess();
 };
 
 export default function build(cli: vorpal) {

--- a/packages/sdk-cli/src/commands/buildAndInstall.test.ts
+++ b/packages/sdk-cli/src/commands/buildAndInstall.test.ts
@@ -54,3 +54,11 @@ it('can be called using the alias "bi"', async () => {
   expect(buildActionSpy).toBeCalled();
   expect(installActionSpy).toBeCalled();
 });
+
+it('does not call install if the build fails', async () => {
+  buildActionSpy.mockReset();
+  buildActionSpy.mockRejectedValueOnce('build error');
+  await expect(cli.exec('build-and-install')).rejects.toBe('build error');
+  expect(buildActionSpy).toBeCalled();
+  expect(installActionSpy).not.toBeCalled();
+});

--- a/packages/sdk-cli/src/commands/buildAndInstall.test.ts
+++ b/packages/sdk-cli/src/commands/buildAndInstall.test.ts
@@ -57,8 +57,8 @@ it('can be called using the alias "bi"', async () => {
 
 it('does not call install if the build fails', async () => {
   buildActionSpy.mockReset();
-  buildActionSpy.mockRejectedValueOnce('build error');
-  await expect(cli.exec('build-and-install')).rejects.toBe('build error');
+  buildActionSpy.mockResolvedValueOnce(false);
+  await expect(cli.exec('build-and-install')).resolves.toBe(false);
   expect(buildActionSpy).toBeCalled();
   expect(installActionSpy).not.toBeCalled();
 });

--- a/packages/sdk-cli/src/commands/buildAndInstall.ts
+++ b/packages/sdk-cli/src/commands/buildAndInstall.ts
@@ -17,8 +17,8 @@ export default function buildAndInstall(
     .command('build-and-install [packagePath]', 'Build and install an application')
     .alias('bi')
     .action(async (args: vorpal.Args & { packagePath?: string }) => {
-      await buildAction(cli);
-      return installAction(cli, stores, args);
+      if (await buildAction(cli)) return installAction(cli, stores, args);
+      return false;
     });
   };
 }


### PR DESCRIPTION
This fixes a bug where the build and install command would still install even if the build failed.