### PR TITLE
Add possibility to invoke command from CLI mode ( without entering interactive mode )

### DIFF
--- a/packages/sdk-cli/src/cli.ts
+++ b/packages/sdk-cli/src/cli.ts
@@ -43,6 +43,8 @@ cli.use(screenshot({ hostConnections }));
 cli.use(setAppPackage({ appContext }));
 cli.use(logout);
 cli.use(repl({ hostConnections }));
+// @ts-ignore
+cli.parse(process.argv);
 
 if (enableQACommands) {
   cli.use(hosts);


### PR DESCRIPTION
Hello! I'm using the Fitbit CLI and I'm really missing a possibility to invoke commands without entering interactive mode. For instance, if I want to build and install my app to invoke only one command: npx fitbit build-and-install

I see a few benefits of having this feature as speed up development and provide better developer experience. It will add the possibility to automate tasks invocation on CI.

I started to look at what are possible scenarios of achieving this. From what I found that there is a proposal to add such feature to vorpal CLI. But also suggested a way of how it can be solved with existed functionality https://github.com/dthree/vorpal/issues/171

Do you see that having this feature is reasonable and this PR makes sense? If yes I would like to add more functionality to check if an existed command was passed as CLI parameter and how it will behave in case of sending multiple parameters. And include proper implementation to PR.

P.S. I've added ts-lint ignore comment because for some reason during build tsc could not find typing but function actually exists.