### PR TITLE
Support logging of protocol messages to a file

### DIFF
--- a/packages/fdb-debugger/src/index.ts
+++ b/packages/fdb-debugger/src/index.ts
@@ -117,6 +117,8 @@ export class RemoteHost extends EventEmitter {
     {
       userAgentSuffix = '',
       timeout = 10000,
+      postDeserializeTransform = new stream.PassThrough({ objectMode: true }),
+      preSerializeTransform = new stream.PassThrough({ objectMode: true }),
     } = {},
   ) {
     let userAgent = this.USER_AGENT;
@@ -127,7 +129,9 @@ export class RemoteHost extends EventEmitter {
     const host = new this(timeout);
     hostStream
       .pipe(new ParseJSON)
+      .pipe(postDeserializeTransform)
       .pipe(host.rpc)
+      .pipe(preSerializeTransform)
       .pipe(host.serializerTransform)
       .pipe(hostStream);
     const reqTime = Date.now();

--- a/packages/sdk-cli/README.md
+++ b/packages/sdk-cli/README.md
@@ -18,3 +18,7 @@ Commands that can be used within the shell
   screenshot [path]      Capture a screenshot from the connected device
   logout                 Log out of your Fitbit account
 ```
+
+#### Debugging
+
+You can capture all Developer Bridge protocol messages for debugging purposes by setting the `FITBIT_DEVBRIDGE_DUMP_PATH` environment variable to a file path before starting the debugger. It is often useful to include this information where possible when reporting bugs.

--- a/packages/sdk-cli/README.md
+++ b/packages/sdk-cli/README.md
@@ -21,4 +21,4 @@ Commands that can be used within the shell
 
 #### Debugging
 
-You can capture all Developer Bridge protocol messages for debugging purposes by setting the `FITBIT_DEVBRIDGE_DUMP_PATH` environment variable to a file path before starting the debugger. It is often useful to include this information where possible when reporting bugs.
+You can capture all Developer Bridge protocol messages for debugging purposes by setting the `FITBIT_DEVBRIDGE_DUMP` environment variable to `1` before starting the debugger. A log file will be written to the working directory for each connection. It is often useful to include this information where possible when reporting bugs.

--- a/packages/sdk-cli/src/models/HostConnections.test.ts
+++ b/packages/sdk-cli/src/models/HostConnections.test.ts
@@ -52,7 +52,7 @@ describe.each([
     });
 
     it('creates a debugger client from the developer relay connection', () => {
-      expect(remoteHostSpy).toBeCalledWith(mockWS);
+      expect(remoteHostSpy).toBeCalledWith(mockWS, undefined);
     });
 
     it('stores the connection in the application state', () => {

--- a/packages/sdk-cli/src/models/HostConnections.ts
+++ b/packages/sdk-cli/src/models/HostConnections.ts
@@ -1,4 +1,5 @@
 import { RemoteHost } from '@fitbit/fdb-debugger';
+import dateformat from 'dateformat';
 import fs from 'fs';
 import stream from 'stream';
 import { SyncEvent } from 'ts-events';
@@ -16,9 +17,10 @@ export class HostConnection {
   ) {}
 
   static getDumpStreamTap() {
-    const dumpLogFilePath = process.env.FITBIT_DEVBRIDGE_DUMP_PATH;
-    if (dumpLogFilePath === undefined) return undefined;
+    const shouldDumpLogFile = process.env.FITBIT_DEVBRIDGE_DUMP === '1';
+    if (!shouldDumpLogFile) return undefined;
 
+    const dumpLogFilePath = dateformat('"log" yyyy-mm-dd "at" H.MM.ss."txt"');
     const dumpLogFileHandle = fs.openSync(dumpLogFilePath, 'w');
     const now = () => new Date().getTime();
     const epoch = now();

--- a/packages/sdk-cli/src/models/StreamTap.ts
+++ b/packages/sdk-cli/src/models/StreamTap.ts
@@ -1,0 +1,14 @@
+import * as stream from 'stream';
+
+export default class StreamTap extends stream.Transform {
+  constructor(private callback: (chunk: any) => void) {
+    super({ objectMode: true });
+  }
+
+  // tslint:disable-next-line:function-name
+  _transform(chunk: any, encoding: string, callback: (err?: Error) => void) {
+    this.callback(chunk);
+    this.push(chunk);
+    callback();
+  }
+}


### PR DESCRIPTION
To enable easier debugging, support logging all developer bridge protocol messages to a file via an `FITBIT_DEVBRIDGE_DUMP` environment variable.