### PR TITLE
Heap snapshot unpacker

### DIFF
--- a/packages/memory-profiler/README.md
+++ b/packages/memory-profiler/README.md
@@ -1,0 +1,7 @@
+@fitbit/memory-profiler
+===============
+
+A collection of tools for analyzing the memory usage of Fitbit SDK applications.
+
+Currently this is only able to unpack a packed heap snapshot into a less compact
+format.

--- a/packages/memory-profiler/package.json
+++ b/packages/memory-profiler/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@fitbit/fdb-protocol",
+  "name": "@fitbit/memory-profiler",
   "version": "1.6.0",
-  "description": "Fitbit Developer Bridge common protocol bits",
+  "description": "Tools for analyzing memory usage of Fitbit SDK applications",
   "files": [
     "/lib/**/!(*.test|*.spec).{js,d.ts}"
   ],
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/Fitbit/developer-bridge/issues"
   },
-  "homepage": "https://github.com/Fitbit/developer-bridge/tree/master/packages/fdb-protocol#readme",
+  "homepage": "https://github.com/Fitbit/developer-bridge/tree/master/packages/memory-profiler#readme",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
@@ -19,17 +19,19 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
+    "@fitbit/app-package": "^1.6.0",
+    "@fitbit/fdb-protocol": "^1.6.0",
     "@fitbit/jsonrpc-ts": "^2.1.0",
-    "invariant": "^2.2.2",
-    "io-ts": "^1.8.3",
-    "semver": "^5.6.0",
+    "cbor": "^4.1.5",
+    "jszip": "^3.2.0",
     "tslib": "^1.9.0",
-    "validator": "^10.11.0"
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
-    "@types/invariant": "^2.2.29",
+    "@types/cbor": "^2.0.0",
+    "@types/jszip": "^3.1.5",
     "@types/node": "^11.9.5",
-    "@types/semver": "^5.5.0",
-    "@types/validator": "^10.9.0"
+    "@types/yargs": "^12.0.10",
+    "io-ts": "^1.8.3"
   }
 }

--- a/packages/memory-profiler/src/cli.ts
+++ b/packages/memory-profiler/src/cli.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+
+import * as AppPackage from '@fitbit/app-package';
+import * as JSZip from 'jszip';
+import * as yargs from 'yargs';
+
+import unpack from './unpack';
+
+async function unpackCommand(
+  snapshotPath: string,
+  fbaPath: string,
+  outputPath: string,
+  deviceType: string,
+) {
+  const fbaData = fs.readFileSync(fbaPath);
+  const fbaZip = await JSZip.loadAsync(fbaData);
+  const fba = await AppPackage.fromJSZip(fbaZip);
+
+  const snapshotBuffer = fs.readFileSync(snapshotPath);
+
+  if (!fba.sourceMaps || !fba.sourceMaps.device || !fba.sourceMaps.device[deviceType]) {
+    throw new Error('Provided FBA file does not contain sourcemaps for requested device type!');
+  }
+
+  const unpackedSnapshot = await unpack(
+    snapshotBuffer,
+    'jerryscript-1',
+    fba.sourceMaps.device[deviceType],
+  );
+
+  fs.writeFileSync(outputPath, JSON.stringify(unpackedSnapshot));
+}
+
+yargs
+  .help()
+  .command(
+    // $0 makes this the default command
+    ['unpack <snapshot> <fba> <output> <deviceType>', '$0'],
+    'Unpack heap snapshot',
+    args =>
+      args
+        .positional('snapshot', { description: 'Heap snapshot path', type: 'string' })
+        .positional('fba', { description: 'FBA file path', type: 'string' })
+        .positional('output', { description: 'Output heap data JSON file path', type: 'string' })
+        .positional('deviceType', { description: 'Device type', type: 'string' })
+        .required(['snapshot', 'fba', 'output', 'deviceType']),
+    (args) => {
+      return unpackCommand(
+        args.snapshot,
+        args.fba,
+        args.output,
+        args.deviceType,
+      ).catch((error) => {
+        process.exitCode = 1;
+        if (error) console.error(error);
+      });
+    },
+  ).argv;

--- a/packages/memory-profiler/src/index.ts
+++ b/packages/memory-profiler/src/index.ts
@@ -1,0 +1,1 @@
+export { default as unpack } from './unpack';

--- a/packages/memory-profiler/src/types.ts
+++ b/packages/memory-profiler/src/types.ts
@@ -1,0 +1,180 @@
+import * as t from 'io-ts';
+
+import { FDBTypes } from '@fitbit/fdb-protocol';
+
+// Runtime types are variables which are used like types, which is
+// reflected in their PascalCase naming scheme.
+/* tslint:disable:variable-name */
+
+export const NodeTypes = t.union([
+  t.literal('Hidden'),
+  t.literal('Array'),
+  t.literal('String'),
+  t.literal('Object'),
+  t.literal('Code'),
+  t.literal('Sourcemap'),
+  t.literal('Closure'),
+  t.literal('Regexp'),
+  t.literal('Heapnumber'),
+  t.literal('Native'),
+  t.literal('Synthetic'),
+  t.literal('Constring'),
+  t.literal('Slicedstring'),
+  t.literal('Symbol'),
+  t.literal('Bigint'),
+]);
+
+export const EdgeTypes = t.union([
+  t.literal('hidden'),
+  t.literal('lexenv'),
+  t.literal('prototype'),
+  t.literal('bind'),
+  t.literal('this'),
+  t.literal('bindargs'),
+  t.literal('element'),
+  t.literal('property'),
+  t.literal('propertyname'),
+  t.literal('propertyget'),
+  t.literal('propertyset'),
+  t.literal('promiseresult'),
+  t.literal('promisefulfill'),
+  t.literal('promisereject'),
+  t.literal('scope'),
+  t.literal('shortcut'),
+  t.literal('weak'),
+]);
+
+export const NodeFields = t.union([
+  t.literal('id'),
+  t.literal('size'),
+  t.literal('repr'),
+]);
+
+export const EdgeFields = t.union([
+  t.literal('from'),
+  t.literal('to'),
+  t.literal('name'),
+]);
+export type EdgeFields = t.TypeOf<typeof EdgeFields>;
+
+export const HeapSnapshot = t.interface(
+  {
+    meta: t.interface({
+      /**
+       * Array of node and edge types included in this snapshot.
+       * Index into this array when decoding an item's type field.
+       */
+      types: t.array(
+        t.union([
+          NodeTypes,
+          EdgeTypes,
+        ]),
+      ),
+
+      /**
+       * List of node field names, in the order they will appear in the representation.
+       * All node items, regardless of their type, will have this same set of fields.
+       * The types given here indicate the type of the field as it will appear in the main payload.
+       * Some of:
+       * * id              (number): unique identifier of node
+       * * size       (number|null): size of node, in bytes (not including children)
+       * * repr (ReprPosition|null): representation of node (e.g. contents of string, name of
+       *                             prototype), can also include source position information.
+       */
+      nodeFields: t.array(NodeFields),
+
+      /**
+       * List of edge field names, in the order they will appear in the representation,
+       * similar to nodeFields.
+       * Some of:
+       * * from (number): id of node that edge originates from
+       * * to   (number): id of node that edge points towards
+       * * name (number|string): name of edge (e.g. property name, array index) as node ID
+       *                         or literal string
+       */
+      edgeFields: t.array(EdgeFields),
+    }),
+
+    /**
+     * Stream of heap layout items, as a flat array.
+     * Each item (node or edge) is represented by a subsequence of form:
+     * [..., type, field1, field2, ..., fieldn, ...]
+     * `type` is an index into the meta.types array, while the balance of fields are as
+     * specified in meta.nodeFields or meta.edgeFields (as appropriate). Nodes and edges
+     * may appear in any order relative to one another. Edges and nodes may be duplicated,
+     * but any duplicates must be identical.
+     */
+    items: t.any,
+  },
+  'HeapSnapshot',
+);
+export type HeapSnapshot = t.TypeOf<typeof HeapSnapshot>;
+
+export const RawPosition = t.union([
+  t.string, // string representation
+  t.tuple([
+    t.union([t.number, t.string]), // source path string or string node ID
+    t.number, // line
+    t.number, // column
+    t.union([t.null, t.string]), // string representation
+  ]),
+  t.null,
+]);
+export type RawPosition = t.TypeOf<typeof RawPosition>;
+
+export const RawNode = t.interface(
+  {
+    type: NodeTypes,
+    id: t.number,
+    size: t.union([t.number, t.null]),
+    repr: RawPosition,
+  },
+  'RawNode',
+);
+export type RawNode = t.TypeOf<typeof RawNode>;
+
+export const Node = t.intersection(
+  [
+    t.interface({
+      type: NodeTypes,
+      id: t.number,
+      size: t.union([t.number, t.null]),
+    }),
+    t.union([
+      t.interface({
+        position: FDBTypes.Position,
+      }),
+      t.partial({
+        repr: t.string,
+      }),
+    ]),
+  ],
+  'Node',
+);
+export type Node = t.TypeOf<typeof Node>;
+
+export const Edge = t.intersection(
+  [
+    t.interface({
+      type: EdgeTypes,
+      to: t.number,
+      from: t.number,
+    }),
+    t.partial({
+      name: t.string,
+    }),
+  ],
+  'Edge',
+);
+export type Edge = t.TypeOf<typeof Edge>;
+
+export const RawEdge = t.interface(
+  {
+    type: EdgeTypes,
+    to: t.number,
+    from: t.number,
+    name: t.union([t.number, t.string, t.null]),
+  },
+  'RawEdge',
+);
+export type RawEdge = t.TypeOf<typeof RawEdge>;

--- a/packages/memory-profiler/src/unpack.ts
+++ b/packages/memory-profiler/src/unpack.ts
@@ -1,0 +1,177 @@
+import * as path from 'path';
+
+import { ComponentSourceMaps } from '@fitbit/app-package';
+import * as cbor from 'cbor';
+import * as t from 'io-ts';
+import { failure } from 'io-ts/lib/PathReporter';
+import * as lodash from 'lodash';
+import { SourceMapConsumer, RawSourceMap } from 'source-map';
+
+import { Edge, HeapSnapshot, Node, NodeTypes, RawNode, RawEdge } from './types';
+
+type RawNodeMap = Record<number, RawNode>;
+type NodeMap = Record<number, Node>;
+
+// TODO: Deduplicate with sdk-cli
+const mapValues = <T, U>(
+  obj: { [s: string]: T },
+  mapper: (value: T, key: string, index: number) => Promise<U> | U,
+) =>
+  Promise.all(
+    Object.entries(obj).map(
+      async ([key, value], index) => ({ [key]: await mapper(value, key, index) })),
+  ).then(entries => entries.reduce((a, b) => ({ ...a, ...b }), {}));
+
+function validateOrThrow<A, O, I>(type: t.Type<A, O, I>, data: I): A {
+  return type.decode(data).getOrElseL((errors) => {
+    throw new Error(failure(errors).join('\n'));
+  });
+}
+
+function normalizeRawNode({ id, type, size, repr }: RawNode, rawNodes: RawNodeMap): Node {
+  if (Array.isArray(repr)) {
+    const [source, line, column, name] = repr;
+    return {
+      id,
+      type,
+      size,
+      position: {
+        line,
+        column,
+        name: name || undefined,
+        source: typeof source === 'string' ? source : rawNodes[source].repr,
+      },
+    };
+  }
+
+  if (repr !== null) {
+    return { id, type, size, repr };
+  }
+
+  return { id, type, size };
+}
+
+function normalizeRawEdge({ type, to, from, name }: RawEdge, nodes: NodeMap): Edge {
+  if (typeof name === 'string') {
+    return { type, to, from, name };
+  }
+
+  if (typeof name === 'number') {
+    const referencedNode = nodes[name];
+    if ('repr' in referencedNode) {
+      return {
+        type,
+        to,
+        from,
+        name: referencedNode.repr,
+      };
+    }
+  }
+
+  return {
+    type,
+    to,
+    from,
+    name: undefined,
+  };
+}
+
+async function applySourceMap(
+  nodes: NodeMap,
+  rawSourceMaps: ComponentSourceMaps,
+) {
+  const sourceMapConsumers = await mapValues(
+    lodash(rawSourceMaps).pickBy().value() as lodash.Dictionary<RawSourceMap>,
+    async map => new SourceMapConsumer(map),
+  );
+
+  for (const node of Object.values(nodes)) {
+    if ('position' in node) {
+      const { line, column, source } = node.position;
+
+      const sourceMap = sourceMapConsumers[path.posix.normalize(source)];
+      if (!sourceMap) continue;
+
+      const mappedPosition = sourceMap.originalPositionFor({
+        column,
+        line: line + 1,
+      });
+
+      if (mappedPosition.source === null) continue;
+
+      node.position = {
+        line: mappedPosition.line - 1,
+        column: mappedPosition.column,
+        source: mappedPosition.source,
+      };
+    }
+  }
+}
+
+export default async function unpack(
+  snapshotBuffer: Buffer,
+  version: string,
+  rawSourceMaps: ComponentSourceMaps,
+): Promise<{
+  version: 'jerryscript-1',
+  nodes: NodeMap,
+  edges: Edge[],
+}> {
+  if (version !== 'jerryscript-1') {
+    throw new Error(`Unknown heap snapshot format "${version}"`);
+  }
+
+  const snapshotCBOR = cbor.decodeFirstSync(snapshotBuffer);
+
+  const { meta, items: packedItems } = validateOrThrow(HeapSnapshot, snapshotCBOR);
+
+  const rawNodes: RawNodeMap = {};
+  const rawEdges: RawEdge[] = [];
+
+  let i = 0;
+  while (i < packedItems.length) {
+    const itemType = meta.types[packedItems[i]];
+    const isNode = NodeTypes.is(itemType);
+
+    // Advance pointer past type field
+    i += 1;
+
+    function unpackFields(fieldNames: string[]) {
+      const fields: Record<string, any> = {};
+      fieldNames.forEach((fieldName) => {
+        fields[fieldName] = packedItems[i];
+        // Advance pointer past field reference
+        i += 1;
+      });
+      return fields;
+    }
+
+    if (isNode) {
+      const rawNode = validateOrThrow(RawNode, {
+        type: itemType,
+        ...unpackFields(meta.nodeFields),
+      });
+      rawNodes[rawNode.id] = rawNode;
+    } else {
+      rawEdges.push(validateOrThrow(RawEdge, {
+        type: itemType,
+        ...unpackFields(meta.edgeFields),
+      }));
+    }
+  }
+
+  const nodes: NodeMap = {};
+  for (const rawNode of Object.values(rawNodes)) {
+    nodes[rawNode.id] = normalizeRawNode(rawNode, rawNodes);
+  }
+
+  const edges = rawEdges.map(rawEdge => normalizeRawEdge(rawEdge, nodes));
+
+  await applySourceMap(nodes, rawSourceMaps);
+
+  return {
+    version,
+    nodes,
+    edges,
+  };
+}

--- a/packages/memory-profiler/tsconfig.json
+++ b/packages/memory-profiler/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.settings.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+  },
+}

--- a/packages/tsconfig.settings.json
+++ b/packages/tsconfig.settings.json
@@ -6,7 +6,7 @@
         "sourceMap": true,
 
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "lib": ["es2017", "dom"],
         "importHelpers": true,
         "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,6 +855,7 @@
 "@types/cbor@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/cbor/-/cbor-2.0.0.tgz#c627afc2ee22f23f2337fecb34628a4f97c6afbb"
+  integrity sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=
   dependencies:
     "@types/node" "*"
 
@@ -1097,6 +1098,11 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@types/yargs@^12.0.10":
+  version "12.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.10.tgz#17a8ec65cd8e88f51b418ceb271af18d3137df67"
+  integrity sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.4.tgz#615bb2adb0cd34c8f4c447b5f6512fa1d8f16a2e"
@@ -1178,6 +1184,11 @@ ansi-regex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
   integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -2381,6 +2392,11 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -2825,6 +2841,11 @@ get-caller-file@^2.0.0:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.1.tgz#25835260d3a2b9665fcdbb08cb039a7bbf7011c0"
   integrity sha512-SpOZHfz845AH0wJYVuZk2jWDqFmu7Xubsx+ldIpwzy5pDUpu7OJHK7QYNSA2NPlDSKQwM1GFaAkciOWjjW92Sg==
 
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
@@ -3262,6 +3283,13 @@ io-ts@^1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.8.2.tgz#4fe3878c147c9851604d36982ee6f64d3e6a4a1e"
   integrity sha512-BvP7iC4bgum5e3Fh82xCUrKWt739osKjmQBMORGij2AOMfTmevj8SEqBhN8EeI0GEwIMHb2bXe4fuikN0lsTWg==
+  dependencies:
+    fp-ts "^1.0.0"
+
+io-ts@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.8.3.tgz#b617159ad030b5c85e14192ffbf24dd054030b38"
+  integrity sha512-zrZRpGNqbuMu8LWJ7lNNQpgdjIiOsNsIfzk8CJpeuVmdnNExGBpb5Wwtp+G9gmMOzLqj4+iFA7+HiFGLzqgBFQ==
   dependencies:
     fp-ts "^1.0.0"
 
@@ -4936,6 +4964,15 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
+os-locale@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  dependencies:
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
+
 os-name@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.0.0.tgz#e1434dbfddb8e74b44c98b56797d951b7648a5d9"
@@ -5615,6 +5652,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6047,6 +6089,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
@@ -6078,6 +6129,13 @@ strip-ansi@^5.0.0:
   integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
   dependencies:
     ansi-regex "^4.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -6824,6 +6882,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.0.0.tgz#3fc44f3e76a8bdb1cc3602e860108602e5ccde8b"
+  integrity sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@^12.0.1:
   version "12.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.2.tgz#fe58234369392af33ecbef53819171eff0f5aadc"
@@ -6858,3 +6924,20 @@ yargs@^12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^13.2.2:
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.2.tgz#0c101f580ae95cea7f39d927e7770e3fdc97f993"
+  integrity sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==
+  dependencies:
+    cliui "^4.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    os-locale "^3.1.0"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.0.0"


### PR DESCRIPTION
Currently this can just unpack the packed snapshot CBOR format into JSON, and do a little bit of denormalizing:

- repr source positions are expanded into a position field and sourcemapped
- source file locations that are referenced via a string node are hydrated into actual strings as if they'd been inlined