### PR TITLE
Fix stream finalization before complete initialisation crashing debugger

### DIFF
--- a/packages/fdb-debugger/src/BulkDataReceiver.test.ts
+++ b/packages/fdb-debugger/src/BulkDataReceiver.test.ts
@@ -1,5 +1,5 @@
 import BulkDataReceiver from './BulkDataReceiver';
-import { FDBTypes } from '@fitbit/fdb-protocol';
+import { FDBTypes, BulkData, BulkDataStream } from '@fitbit/fdb-protocol';
 
 // All the other BulkDataReceiver behaviour is thoroughly covered by the
 // screenshot tests in index.test.ts.
@@ -34,4 +34,114 @@ it('registers closer methods with arbitrary names', () => {
   expect(dispatcher.method).toHaveBeenCalledWith(
     'bar.baz.undo', FDBTypes.StreamCloseParams, receiver.abortStream,
   );
+});
+
+describe('when the stream open promise resolution is delayed', () => {
+  let openResolve: () => void;
+  let openReject: (error: Error) => void;
+
+  let receiver: BulkDataReceiver;
+
+  let openPromise: Promise<Buffer>;
+  let openResolvedMockFn: jest.Mock;
+  let openRejectedMockFn: jest.Mock;
+
+  let mockBulkDataStream: Partial<BulkDataStream>;
+
+  beforeEach(() => {
+    mockBulkDataStream = {
+      token: 0,
+      finalize: jest.fn(),
+    };
+
+    const mockBulkData: Partial<BulkData> = {
+      createWriteStream: () => mockBulkDataStream as BulkDataStream,
+    };
+
+    receiver = new BulkDataReceiver(mockBulkData as Partial<BulkData> as BulkData, 'test');
+
+    openPromise = receiver.receiveFromStream(() => new Promise((resolve, reject) => {
+      openResolve = resolve;
+      openReject = reject;
+    }));
+
+    openResolvedMockFn = jest.fn();
+    openRejectedMockFn = jest.fn();
+    openPromise.then(openResolvedMockFn, openRejectedMockFn);
+  });
+
+  describe('receiveFromStream()', () => {
+    it('rejects if the open call rejects', () => {
+      openReject(new Error('failed to open'));
+      return expect(openPromise).rejects.toThrowError();
+    });
+
+    it('resolves with finalized data', async () => {
+      const fakeData = Buffer.from('some data');
+      (mockBulkDataStream.finalize as jest.Mock).mockReturnValueOnce(fakeData);
+      openResolve();
+      await receiver.finalizeStream({ stream: 0 });
+      return expect(openPromise).resolves.toBe(fakeData);
+    });
+  });
+
+  describe('finalizeStream()', () => {
+    let finalizePromise: Promise<void>;
+
+    beforeEach(() => {
+      finalizePromise = receiver.finalizeStream({ stream: 0 });
+    });
+
+    it('does not resolve until open promise resolves', async () => {
+      const finalizeResolvedMockFn = jest.fn();
+      finalizePromise.then(finalizeResolvedMockFn);
+
+      expect(finalizeResolvedMockFn).not.toBeCalled();
+
+      openResolve();
+      await finalizePromise;
+
+      expect(finalizeResolvedMockFn).toBeCalled();
+    });
+
+    it('resolves if stream open succeeds', () => {
+      openResolve();
+      return expect(finalizePromise).resolves.toBeUndefined();
+    });
+
+    it('rejects if stream open failed', () => {
+      openReject(new Error('failed to open'));
+      return expect(finalizePromise).rejects.toThrowError();
+    });
+  });
+
+  describe('abortStream()', () => {
+    let abortPromise: Promise<void>;
+
+    beforeEach(() => {
+      abortPromise = receiver.abortStream({ stream: 0 });
+    });
+
+    it('does not resolve until open promise resolves', async () => {
+      const abortResolvedMockFn = jest.fn();
+      abortPromise.then(abortResolvedMockFn);
+
+      expect(abortResolvedMockFn).not.toBeCalled();
+
+      openResolve();
+      await abortPromise;
+
+      expect(abortResolvedMockFn).toBeCalled();
+    });
+
+    it('resolves if stream open succeeds', () => {
+      openResolve();
+      return expect(abortPromise).resolves.toBeUndefined();
+    });
+
+    it('rejects if stream open failed', () => {
+      openReject(new Error('failed to open'));
+      return expect(abortPromise).rejects.toThrowError();
+    });
+  });
 });

--- a/packages/fdb-debugger/src/BulkDataReceiver.ts
+++ b/packages/fdb-debugger/src/BulkDataReceiver.ts
@@ -65,9 +65,7 @@ export default class BulkDataReceiver {
         await context.openPromise;
         this.contexts.delete(token);
         return context;
-      } catch (ex) {
-        // Fallthrough to throw below
-      }
+      } catch {} // Fallthrough to throw below
     }
 
     throw new InvalidParams(

--- a/packages/fdb-debugger/src/index.test.ts
+++ b/packages/fdb-debugger/src/index.test.ts
@@ -695,7 +695,7 @@ it('handles attempts to finalize a nonexistent screenshot stream', async () => {
   await init();
   return expect(mockHost.callMethod('app.screenshot.stream.finalize', { stream: 'foo' }))
     .rejects.toEqual(expect.objectContaining({
-      message: 'Stream token does not match any open screenshot stream',
+      message: "Stream token 'foo' does not match any open screenshot stream",
     }));
 });
 
@@ -703,7 +703,7 @@ it('handles attempts to abort a nonexistent screenshot stream', async () => {
   await init();
   return expect(mockHost.callMethod('app.screenshot.stream.abort', { stream: 'foo' }))
     .rejects.toEqual(expect.objectContaining({
-      message: 'Stream token does not match any open screenshot stream',
+      message: "Stream token 'foo' does not match any open screenshot stream",
     }));
 });
 


### PR DESCRIPTION
There's a case where if the device responds to the open file contents sequence of events very quickly, it's possible that we try to process a finalize call before we've actually registered the stream.

Sequence of events:

1) Send to device request for data
2) Get ACK
3) Get some data
4) ACK it
5) Get a finalize call

If the device sends 5) before we can register the stream as open after receiving the ACK in 2), things blow up.

This change switches things around so that finalize/abort will wait for the stream to be registered and ready before doing what they'd normally do.