### PR TITLE
Hack around invalid typing in memory-profiler

### DIFF
--- a/packages/memory-profiler/src/unpack.ts
+++ b/packages/memory-profiler/src/unpack.ts
@@ -39,7 +39,8 @@ function normalizeRawNode({ id, type, size, repr }: RawNode, rawNodes: RawNodeMa
         line,
         column,
         name: name || undefined,
-        source: typeof source === 'string' ? source : rawNodes[source].repr,
+        // TODO: this isn't right, but it was how it behaved before the TS update
+        source: typeof source === 'string' ? source : rawNodes[source].repr as string,
       },
     };
   }


### PR DESCRIPTION
This got broken because TS got smarter, but we didn't catch it because the memory profiler is a prototype and has no tests yet. Unfortunately, it blocks publishing, so temporarily typecasting it to make it quietly behave as before.

We'll need to go back and actually fix the thing TS is now pointing out. Nothing actually consumes this package yet, so this is hopefully okay.