### PR TITLE
Disable broken incremental build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Thumbs.db
 packages/*/dist/**/*
 packages/*/lib/**/*
 packages/*/mod/**/*
+
+tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "homepage": "https://github.com/Fitbit/developer-bridge#readme",
   "scripts": {
-    "build": "rm -rf packages/*/lib && tsc -b packages",
+    "build": "rm -rf packages/*/lib && rm -rf packages/*/tsconfig.tsbuildinfo && tsc -b packages",
     "test": "jest",
     "test:coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
     "lint": "tslint --project packages/tsconfig.settings.json --format code-frame",

--- a/packages/app-package/package.json
+++ b/packages/app-package/package.json
@@ -12,7 +12,7 @@
   "main": "lib/AppPackage.js",
   "types": "lib/AppPackage.d.ts",
   "scripts": {
-    "build": "rm -rf lib && tsc -b",
+    "build": "rm -rf lib tsconfig.tsbuildinfo && tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "files": [

--- a/packages/fdb-debugger/package.json
+++ b/packages/fdb-debugger/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "rm -rf lib && tsc -b",
+    "build": "rm -rf lib tsconfig.tsbuildinfo && tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {

--- a/packages/fdb-host/package.json
+++ b/packages/fdb-host/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "rm -rf lib && tsc -b",
+    "build": "rm -rf lib tsconfig.tsbuildinfo && tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {

--- a/packages/fdb-protocol/package.json
+++ b/packages/fdb-protocol/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "rm -rf lib && tsc -b",
+    "build": "rm -rf lib tsconfig.tsbuildinfo && tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {

--- a/packages/memory-profiler/package.json
+++ b/packages/memory-profiler/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "rm -rf lib && tsc -b",
+    "build": "rm -rf lib tsconfig.tsbuildinfo && tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {

--- a/packages/sdk-cli/package.json
+++ b/packages/sdk-cli/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Fitbit/developer-bridge/tree/master/packages/sdk-cli#readme",
   "scripts": {
-    "build": "rm -rf lib && tsc -b",
+    "build": "rm -rf lib tsconfig.tsbuildinfo && tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {


### PR DESCRIPTION
TypeScript has incremental build support now! Unfortunately, it basically completely broke publishing this repo.

Each of our packages has `rm -rf lib && tsc -b` which worked fine before. With the now-default incremental building, running this will not re-generate the `lib` folder. Which results in publishing an entirely empty package.

You can't disable incremental builds for a composite project, so for now, let's also delete the cache files so this works as it did before.

Note there is a "clean" option (`tsc -b --clean`) but it's not quite the same, as it won't delete random stray files that happen to be in the `lib` folder.