### PR TITLE
Add --skipLaunch option to install

### DIFF
--- a/packages/sdk-cli/src/commands/install.test.ts
+++ b/packages/sdk-cli/src/commands/install.test.ts
@@ -78,8 +78,10 @@ let sideloadCompanionSpy: jest.SpyInstance;
 let appContext: AppContext;
 let hostConnections: HostConnections;
 
-function doInstall() {
-  return cli.exec('install');
+function doInstall({ skipLaunch } : { skipLaunch?: boolean } = {}) {
+  let cmd = 'install';
+  if (skipLaunch) cmd += ' --skipLaunch';
+  return cli.exec(cmd);
 }
 
 function expectConnect(deviceType: string) {
@@ -167,7 +169,7 @@ describe('when an app is loaded', () => {
     });
 
     describe('when sideloading is successful', () => {
-      beforeEach(doInstall);
+      beforeEach(() => doInstall());
 
       it('sideloads the app', () => {
         expect(sideloadAppSpy).toBeCalled();
@@ -184,6 +186,14 @@ describe('when an app is loaded', () => {
         mockDevice.host.info.capabilities.appHost.launch.appComponent.canLaunch = false;
         return doInstall();
       });
+      it('does not launch the app', () => {
+        expect(mockDevice.host.launchAppComponent).not.toBeCalled();
+      });
+    });
+
+    describe('when skipLaunch is specified', () => {
+      beforeEach(() => doInstall({ skipLaunch: true }));
+
       it('does not launch the app', () => {
         expect(mockDevice.host.launchAppComponent).not.toBeCalled();
       });


### PR DESCRIPTION
Currently it's difficult to test how your app behaves in cases like modifying settings or running companion code before the app has been launched for the first time on device, because installing implicitly launches. This change makes it so you can skip launching to test this specific scenario.