### PR TITLE
Fix broken memory profiler build

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "fdb-protocol" },
     { "path": "fdb-host" },
     { "path": "fdb-debugger" },
+    { "path": "memory-profiler" },
     { "path": "sdk-cli" },
   ],
 }


### PR DESCRIPTION
Missed this before when updating io-ts because our publish step runs `yarn build` per package, but our CI runs it for the whole project. Our tsconfig was missing this package, so it wasn't building this package and failing CI. Added it and fixed the bug.

Signed-off-by: Liam McLoughlin <liam.mcloughlin@fitbit.com>