### PR TITLE
Replace Node 10 with Node 16 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node_version: [10, 12, 14]
+        node_version: [12, 14, 16]
     name: ${{ matrix.os }} / Node v${{ matrix.node_version }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Node 10 is now out of LTS support period and no longer supported,
so we drop support also. Replaced with the new LTS, Node 16.

Signed-off-by: Liam McLoughlin <lmcloughlin@google.com>