### PR TITLE
Fix "companion unloaded"

### DIFF
--- a/packages/sdk-cli/src/commands/install.ts
+++ b/packages/sdk-cli/src/commands/install.ts
@@ -116,8 +116,10 @@ export const installAction = async (
         )
         .then(printCompletionStatus('Companion'));
     }
-  } catch (ex) {
-    cli.activeCommand.log(`Install failed: ${ex.message}`);
+  } catch (ex: any) {
+    if (ex instanceof Error) {
+      cli.activeCommand.log(`Install failed: ${ex.message}`);
+    } else { cli.activeCommand.log(`Install failed: ${ex}`); }
     return false;
   }
 
@@ -127,11 +129,22 @@ export const installAction = async (
       appHost.host.info.capabilities.appHost!.launch!.appComponent!.canLaunch
     ) {
       if (args.options.skipLaunch !== true) {
-        cli.activeCommand.log('Launching app');
-        await appHost.host.launchAppComponent({
-          uuid: appPackage.uuid,
-          component: 'app',
-        });
+        // let the compagnion unload before launching the app again.
+        if (companionHost && !companionHost.host.info.device.startsWith('Fitbit OS Simulator')) {
+          setTimeout(() => {
+            cli.activeCommand.log('Launching app');
+            appHost.host.launchAppComponent({
+              uuid: appPackage.uuid,
+              component: 'app',
+            });
+          }, 3000); 
+        } else {
+          cli.activeCommand.log('Launching app');
+          await appHost.host.launchAppComponent({
+            uuid: appPackage.uuid,
+            component: 'app',
+          });
+        }
       }
     } else {
       cli.activeCommand.log('Device does not support launching app remotely');


### PR DESCRIPTION
Fix the "Compagnion Unloaded" issue that is pretty annoying. 

Simply by waiting 3 second before installing the app.
![image](https://user-images.githubusercontent.com/66485277/143953280-af333551-ceb4-4b7c-815c-93af575e3e14.png)

I also added checks since this issue only apply to real devices
![image](https://user-images.githubusercontent.com/66485277/143953389-35887133-8a23-47bc-9ad1-b3b062b95040.png)

